### PR TITLE
AOAIからのレスポンスのハンドリングを実装

### DIFF
--- a/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
@@ -45,7 +45,7 @@ public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppCo
 
         if (chatResult.Value.FinishReason == ChatFinishReason.ToolCalls)
         {
-            var result = new AgentDeciderResult
+            return new AgentDeciderResult
             {
                 IsAgentCall = true,
                 AgentCalls = chatResult.Value.ToolCalls.Select(toolCall => new AgentCall
@@ -54,15 +54,19 @@ public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppCo
                     Arguments = JsonDocument.Parse(toolCall.FunctionArguments)
                 }).ToArray()
             };
-            return result;
         }
         else
         {
-            return new AgentDeciderResult
+            if (chatResult.Value.FinishReason == ChatFinishReason.Stop)
             {
-                IsAgentCall = false,
-                Content = chatResult.Value.Content.First().Text
-            };
+                return new AgentDeciderResult
+                {
+                    IsAgentCall = false,
+                    Content = chatResult.Value.Content.First().Text
+                };
+            }
         }
+        
+        throw new InvalidOperationException("Invalid OpenAI response");
     }
 }

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerActivity.cs
@@ -31,12 +31,15 @@ public class SynthesizerActivity(AzureOpenAIClient openAIClient, IOptions<AppCon
             allMessages
         );
 
-        var res = new AgentResponseDto
+        if (chatResult.Value.FinishReason == ChatFinishReason.Stop)
         {
-            Content = chatResult.Value.Content.First().Text,
-            CalledAgentNames = req.CalledAgentNames
-        };
+            return new AgentResponseDto
+            {
+                Content = chatResult.Value.Content.First().Text,
+                CalledAgentNames = req.CalledAgentNames
+            };
+        }
 
-        return res;
+        throw new InvalidOperationException("Failed to synthesize the result");
     }
 }


### PR DESCRIPTION
このプルリクエストには、エラーハンドリングの改善と `DurableMultiAgentTemplate/Agent/Orchestrator` ディレクトリ内のコードの効率化を目的としたいくつかの変更が含まれています。主な変更点は、メソッドを直接結果を返すように修正し、不正なレスポンスに対するエラーハンドリングを追加し、レスポンスの適切なデシリアライズを確保することです。

### エラーハンドリングの改善:

- **[`[DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL48-R48)`](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL48-R48):**  
  `Run` メソッドを修正し、`AgentDeciderResult` を直接返すよう変更。不正な OpenAI レスポンスに対するエラーハンドリングを追加。  
  [[[1]](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL48-R48)](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL48-R48)  
  [[[2]](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL57-R60)](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dL57-R60)  
  [[[3]](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dR69-R71)](diffhunk://#diff-efd71fd2829bc1a6e843cd5c966c45f29594aa5393ad9c339c90d85cd223b67dR69-R71)

- **[`[DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerActivity.cs](diffhunk://#diff-544fa5933bb280baec30075cfee55c842f82107c927992f075f140fa1f2d5eb0L34-R43)`](diffhunk://#diff-544fa5933bb280baec30075cfee55c842f82107c927992f075f140fa1f2d5eb0L34-R43):**  
  `FinishReason` が `ChatFinishReason.Stop` でない場合のエラーハンドリングを追加し、合成失敗時に `InvalidOperationException` をスロー。

- **[`[DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerWithAdditionalInfoActivity.cs](diffhunk://#diff-fa66c44e99cddf5e76e77a6ca01d9e4e8997b906b2355a29d19554d3c89fb83bL44-R62)`](diffhunk://#diff-fa66c44e99cddf5e76e77a6ca01d9e4e8997b906b2355a29d19554d3c89fb83bL44-R62):**  
  デシリアライズ失敗時のエラーハンドリングを追加し、`Content` および `AdditionalInfo` が `null` でないことを保証するよう変更。これらが `null` の場合には `InvalidOperationException` をスロー。


Fix #7 