### PR TITLE
エージェントチャットのタイムアウト処理を追加

### DIFF
--- a/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
+++ b/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
@@ -1,10 +1,8 @@
-﻿using System.Xml.Xsl;
-using DurableMultiAgentTemplate.Client.Components.Utilities;
+﻿using DurableMultiAgentTemplate.Client.Components.Utilities;
 using DurableMultiAgentTemplate.Client.Model;
 using DurableMultiAgentTemplate.Client.Services;
 using DurableMultiAgentTemplate.Client.Utilities;
 using DurableMultiAgentTemplate.Model;
-using Microsoft.FluentUI.AspNetCore.Components;
 
 namespace DurableMultiAgentTemplate.Client.Components.Pages;
 

--- a/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
+++ b/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
@@ -1,4 +1,5 @@
-﻿using DurableMultiAgentTemplate.Client.Components.Utilities;
+﻿using System.Xml.Xsl;
+using DurableMultiAgentTemplate.Client.Components.Utilities;
 using DurableMultiAgentTemplate.Client.Model;
 using DurableMultiAgentTemplate.Client.Services;
 using DurableMultiAgentTemplate.Client.Utilities;
@@ -9,6 +10,8 @@ namespace DurableMultiAgentTemplate.Client.Components.Pages;
 
 public partial class Home(AgentChatService agentChatService, ILogger<Home> logger)
 {
+    private const int _chatTimeoutMs = 20000;
+
     private readonly ScrollToBottomContext _scrollToBottomContext = new();
     private readonly ExecutionTracker _executionTracker = new();
     private readonly ChatInput _chatInput = new();
@@ -17,6 +20,14 @@ public partial class Home(AgentChatService agentChatService, ILogger<Home> logge
 
     private async Task SendMessageAsync()
     {
+        void handleError(string originalInputMessage, string errorMessage)
+        {
+            _chatInput.Message = originalInputMessage;
+            _messages.RemoveAt(_messages.Count - 1);
+            _messages.Add(new InfoChatMessage($"Failed to send message: {errorMessage}", false));
+            _scrollToBottomContext.RequestScrollToBottom();
+        }
+
         if (_executionTracker.IsInProgress) return;
         using var _ = _executionTracker.Start();
         if (string.IsNullOrWhiteSpace(_chatInput.Message)) return;
@@ -29,7 +40,9 @@ public partial class Home(AgentChatService agentChatService, ILogger<Home> logge
 
         try
         {
-            var response = await agentChatService.GetAgentResponseAsync(new AgentRequestDto
+            // Send the message to the agent
+            using CancellationTokenSource cancellationTokenSource = new();
+            var getAgentResponseTask = agentChatService.GetAgentResponseAsync(new AgentRequestDto
             {
                 Messages = _messages.Where(x => x.IsRequestTarget).Select(x => x switch
                 {
@@ -47,7 +60,20 @@ public partial class Home(AgentChatService agentChatService, ILogger<Home> logge
                 })
                 .ToList(),
                 RequireAdditionalInfo = _chatInput.RequireAdditionalInfo,
-            });
+            }, cancellationTokenSource.Token);
+
+            // Wait for the agent response or timeout
+            var winner = await Task.WhenAny(getAgentResponseTask, Task.Delay(_chatTimeoutMs));
+            if (winner != getAgentResponseTask)
+            {
+                // Timeout
+                cancellationTokenSource.Cancel();
+                handleError(message,"The request timed out. Please try again.");
+                return;
+            }
+
+            // Process the agent response
+            var response = await getAgentResponseTask;
             _messages.RemoveAt(_messages.Count - 1);
             _messages.Add(new AgentChatMessage(response));
 
@@ -62,10 +88,7 @@ public partial class Home(AgentChatService agentChatService, ILogger<Home> logge
         catch (Exception e)
         {
             logger.LogError(e, "Failed to send message: {Message}", message);
-            _chatInput.Message = message;
-            _messages.RemoveAt(_messages.Count - 1);
-            _messages.Add(new InfoChatMessage($"Failed to send message: {e.Message}", false));
-            _scrollToBottomContext.RequestScrollToBottom();
+            handleError(message,$"Failed to send message: {e.Message}");
         }
     }
 

--- a/DurableMultiAgentTemplate.Client/Services/AgentChatService.cs
+++ b/DurableMultiAgentTemplate.Client/Services/AgentChatService.cs
@@ -37,7 +37,7 @@ public class AgentChatService(HttpClient httpClient)
         }
 
         // If the cancellation token is requested, terminate the agent response.
-        await httpClient.PostAsync(invokeAsyncResult.TerminatePostUri, null);
+        await httpClient.PostAsync(invokeAsyncResult.TerminatePostUri, null, CancellationToken.None);
         throw new TaskCanceledException("The agent response is not ready.");
     }
 

--- a/DurableMultiAgentTemplate.Client/Services/AgentChatService.cs
+++ b/DurableMultiAgentTemplate.Client/Services/AgentChatService.cs
@@ -1,14 +1,46 @@
-﻿using DurableMultiAgentTemplate.Model;
+﻿using System.Text.Json;
+using DurableMultiAgentTemplate.Model;
 
 namespace DurableMultiAgentTemplate.Client.Services;
 
 public class AgentChatService(HttpClient httpClient)
 {
-    public async Task<AgentResponseWithAdditionalInfoDto> GetAgentResponseAsync(AgentRequestDto agentRequestDto)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions
     {
-        var response = await httpClient.PostAsJsonAsync("invoke/sync", agentRequestDto);
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    public async Task<AgentResponseWithAdditionalInfoDto> GetAgentResponseAsync(AgentRequestDto agentRequestDto, CancellationToken cancellationToken)
+    {
+        var response = await httpClient.PostAsJsonAsync("invoke/async", agentRequestDto, cancellationToken);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadFromJsonAsync<AgentResponseWithAdditionalInfoDto>() ??
+
+        var invokeAsyncResult = await response.Content.ReadFromJsonAsync<InvokeAsyncResult>(_jsonSerializerOptions, cancellationToken);
+        if (invokeAsyncResult == null)
+        {
             throw new InvalidOperationException("The format of the response from the agent is invalid.");
+        }
+
+        // The response from the agent is an async response, so we need to poll the status until it's completed.
+        while (cancellationToken.IsCancellationRequested == false)
+        {
+            var statusResponse = await httpClient.GetAsync(invokeAsyncResult.StatusQueryGetUri, cancellationToken);
+            statusResponse.EnsureSuccessStatusCode();
+            var status = await statusResponse.Content.ReadFromJsonAsync<OrchestrationStatus>(_jsonSerializerOptions, cancellationToken)
+                ?? throw new InvalidOperationException("The format of the status response from the agent is invalid.");
+            if (status.RuntimeStatus == "Completed")
+            {
+                return status.Output ?? throw new InvalidOperationException("The format of the output from the agent is invalid.");
+            }
+
+            await Task.Delay(1000, cancellationToken);
+        }
+
+        // If the cancellation token is requested, terminate the agent response.
+        await httpClient.PostAsync(invokeAsyncResult.TerminatePostUri, null);
+        throw new TaskCanceledException("The agent response is not ready.");
     }
+
+    record InvokeAsyncResult(string Id, string StatusQueryGetUri, string TerminatePostUri);
+    record class OrchestrationStatus(string RuntimeStatus, AgentResponseWithAdditionalInfoDto? Output);
 }

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerWithAdditionalInfoActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerWithAdditionalInfoActivity.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Azure.AI.OpenAI;
 using DurableMultiAgentTemplate.Extension;
 using DurableMultiAgentTemplate.Json;

--- a/DurableMultiAgentTemplate/Model/AgentRequestDto.cs
+++ b/DurableMultiAgentTemplate/Model/AgentRequestDto.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace DurableMultiAgentTemplate.Model;
 
 public class AgentRequestDto

--- a/DurableMultiAgentTemplate/Model/AgentResponseDto.cs
+++ b/DurableMultiAgentTemplate/Model/AgentResponseDto.cs
@@ -1,5 +1,3 @@
-using System.Text.Json.Serialization;
-
 namespace DurableMultiAgentTemplate.Model;
 
 public class AgentResponseDto

--- a/DurableMultiAgentTemplate/Model/AgentResponseWithAdditionalInfoDto.cs
+++ b/DurableMultiAgentTemplate/Model/AgentResponseWithAdditionalInfoDto.cs
@@ -1,6 +1,3 @@
-using System.ComponentModel;
-using System.Text.Json.Serialization;
-
 namespace DurableMultiAgentTemplate.Model;
 
 public class AgentResponseWithAdditionalInfoDto:AgentResponseDto

--- a/DurableMultiAgentTemplate/Program.cs
+++ b/DurableMultiAgentTemplate/Program.cs
@@ -6,7 +6,6 @@ using Azure.Core;
 using Azure.Identity;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 

--- a/DurableMultiAgentTemplate/Starter.cs
+++ b/DurableMultiAgentTemplate/Starter.cs
@@ -1,7 +1,6 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using DurableMultiAgentTemplate.Agent.Orchestrator;
 using DurableMultiAgentTemplate.Model;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.DurableTask.Client;


### PR DESCRIPTION
`Home` クラスに `_chatTimeoutMs` 定数と `handleError` メソッドを追加しました。`SendMessageAsync` メソッド内でタイムアウト処理を追加。

`AgentChatService.cs` の `GetAgentResponseAsync` メソッドを更新し、非同期エージェント応答の処理、ポーリングによるステータス確認、タイムアウト処理を行うようにしました。