### PR TITLE
Cosmos DB への接続のためのクライアントを追加

### DIFF
--- a/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
+++ b/DurableMultiAgentTemplate.Client/Components/Pages/Home.razor.cs
@@ -8,7 +8,7 @@ namespace DurableMultiAgentTemplate.Client.Components.Pages;
 
 public partial class Home(AgentChatService agentChatService, ILogger<Home> logger)
 {
-    private const int _chatTimeoutMs = 20000;
+    private const int _chatTimeoutMs = 60000;
 
     private readonly ScrollToBottomContext _scrollToBottomContext = new();
     private readonly ExecutionTracker _executionTracker = new();

--- a/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
@@ -3,16 +3,13 @@ using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.GetClimateAgent;
 
-public class GetClimateActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfig> configuration,
+public class GetClimateActivity(ChatClient chatClient, 
     ILogger<GetClimateActivity> logger)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.GetClimateAgent)]
     public string Run([ActivityTrigger] GetClimateRequest req, FunctionContext executionContext)
     {

--- a/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.Options;
 namespace DurableMultiAgentTemplate.Agent.GetClimateAgent;
 
 public class GetClimateActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfiguration> configuration,
+    IOptions<AppConfig> configuration,
     ILogger<GetClimateActivity> logger)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.GetClimateAgent)]
     public string Run([ActivityTrigger] GetClimateRequest req, FunctionContext executionContext)

--- a/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.Options;
 namespace DurableMultiAgentTemplate.Agent.GetDestinationSuggestAgent;
 
 public class GetDestinationSuggestActivity(AzureOpenAIClient openAIClient,
-    IOptions<AppConfiguration> configuration,
+    IOptions<AppConfig> configuration,
     ILogger<GetDestinationSuggestActivity> logger)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.GetDestinationSuggestAgent)]
     public string Run([ActivityTrigger] GetDestinationSuggestRequest req, FunctionContext executionContext)

--- a/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
@@ -3,16 +3,13 @@ using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.GetDestinationSuggestAgent;
 
-public class GetDestinationSuggestActivity(AzureOpenAIClient openAIClient,
-    IOptions<AppConfig> configuration,
+public class GetDestinationSuggestActivity(ChatClient chatClient,
     ILogger<GetDestinationSuggestActivity> logger)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.GetDestinationSuggestAgent)]
     public string Run([ActivityTrigger] GetDestinationSuggestRequest req, FunctionContext executionContext)
     {

--- a/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
@@ -3,16 +3,13 @@ using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.GetHotelAgent;
 
-public class GetHotelActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfig> configuration, 
+public class GetHotelActivity(ChatClient chatClient, 
     ILogger<GetHotelActivity> logger)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.GetHotelAgent)]
     public string Run([ActivityTrigger] GetHotelRequest req, FunctionContext executionContext)
     {

--- a/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.Options;
 namespace DurableMultiAgentTemplate.Agent.GetHotelAgent;
 
 public class GetHotelActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfiguration> configuration, 
+    IOptions<AppConfig> configuration, 
     ILogger<GetHotelActivity> logger)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.GetHotelAgent)]
     public string Run([ActivityTrigger] GetHotelRequest req, FunctionContext executionContext)

--- a/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
@@ -3,16 +3,13 @@ using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.GetSightseeingSpotAgent;
 
-public class GetSightseeingSpotActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfig> configuration,
+public class GetSightseeingSpotActivity(ChatClient chatClient,
     ILogger<GetSightseeingSpotActivity> logger)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.GetSightseeingSpotAgent)]
     public string Run([ActivityTrigger] GetSightseeingSpotRequest req, FunctionContext executionContext)
     {

--- a/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
@@ -7,11 +7,11 @@ using Microsoft.Extensions.Options;
 namespace DurableMultiAgentTemplate.Agent.GetSightseeingSpotAgent;
 
 public class GetSightseeingSpotActivity(AzureOpenAIClient openAIClient, 
-    IOptions<AppConfiguration> configuration,
+    IOptions<AppConfig> configuration,
     ILogger<GetSightseeingSpotActivity> logger)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.GetSightseeingSpotAgent)]
     public string Run([ActivityTrigger] GetSightseeingSpotRequest req, FunctionContext executionContext)

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
@@ -10,11 +10,8 @@ using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.Orchestrator;
 
-public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppConfig> configuration)
+public class AgentDeciderActivity(ChatClient chatClient)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.AgentDeciderActivity)]
     public async Task<AgentDeciderResult> Run([ActivityTrigger] AgentRequestDto reqData, FunctionContext executionContext)
     {
@@ -37,7 +34,6 @@ public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppCo
             }
         };
 
-        var chatClient = _openAIClient.GetChatClient(_configuration.OpenAI.Deploy);
         var chatResult = await chatClient.CompleteChatAsync(
             allMessages,
             options

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/AgentDeciderActivity.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using Azure.AI.OpenAI;
 using DurableMultiAgentTemplate.Extension;
 using DurableMultiAgentTemplate.Model;
@@ -10,10 +10,10 @@ using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.Orchestrator;
 
-public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppConfiguration> configuration)
+public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppConfig> configuration)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.AgentDeciderActivity)]
     public async Task<AgentDeciderResult> Run([ActivityTrigger] AgentRequestDto reqData, FunctionContext executionContext)
@@ -37,7 +37,7 @@ public class AgentDeciderActivity(AzureOpenAIClient openAIClient, IOptions<AppCo
             }
         };
 
-        var chatClient = _openAIClient.GetChatClient(_configuration.OpenAIDeploy);
+        var chatClient = _openAIClient.GetChatClient(_configuration.OpenAI.Deploy);
         var chatResult = await chatClient.CompleteChatAsync(
             allMessages,
             options

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerActivity.cs
@@ -1,4 +1,4 @@
-using Azure.AI.OpenAI;
+﻿using Azure.AI.OpenAI;
 using DurableMultiAgentTemplate.Extension;
 using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
@@ -8,11 +8,8 @@ using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.Orchestrator;
 
-public class SynthesizerActivity(AzureOpenAIClient openAIClient, IOptions<AppConfiguration> configuration)
+public class SynthesizerActivity(ChatClient chatClient)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
-
     [Function(AgentActivityName.SynthesizerActivity)]
     public async Task<AgentResponseDto> Run([ActivityTrigger] SynthesizerRequest req, FunctionContext executionContext)
     {
@@ -26,7 +23,6 @@ public class SynthesizerActivity(AzureOpenAIClient openAIClient, IOptions<AppCon
             .. req.AgentReques.Messages.ConvertToChatMessageArray(),
         ];
 
-        var chatClient = _openAIClient.GetChatClient(_configuration.OpenAIDeploy);
         var chatResult = await chatClient.CompleteChatAsync(
             allMessages
         );

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerWithAdditionalInfoActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/SynthesizerWithAdditionalInfoActivity.cs
@@ -1,4 +1,5 @@
-using System.Text.Json;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.AI.OpenAI;
 using DurableMultiAgentTemplate.Extension;
 using DurableMultiAgentTemplate.Json;
@@ -10,11 +11,8 @@ using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.Orchestrator;
 
-public class SynthesizerWithAdditionalInfoActivity(AzureOpenAIClient openAIClient, IOptions<AppConfiguration> configuration)
+public class SynthesizerWithAdditionalInfoActivity(ChatClient chatClient)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
-
     [Function(AgentActivityName.SynthesizerWithAdditionalInfoActivity)]
     public async Task<AgentResponseWithAdditionalInfoDto> Run([ActivityTrigger] SynthesizerRequest req, FunctionContext executionContext)
     {
@@ -35,7 +33,6 @@ public class SynthesizerWithAdditionalInfoActivity(AzureOpenAIClient openAIClien
             JsonSchemaGenerator.GenerateSchemaAsBinaryData(SourceGenerationContext.Default.AgentResponseWithAdditionalInfoFormat))
         };
 
-        var chatClient = _openAIClient.GetChatClient(_configuration.OpenAIDeploy);
         var chatResult = await chatClient.CompleteChatAsync(
             allMessages,
             options

--- a/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
@@ -1,15 +1,14 @@
-using Azure.AI.OpenAI;
+﻿using Azure.AI.OpenAI;
 using DurableMultiAgentTemplate.Model;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Options;
+using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.SubmitReservationAgent;
 
-public class SubmitReservationActivity(AzureOpenAIClient openAIClient, IOptions<AppConfig> configuration)
+public class SubmitReservationActivity(ChatClient chatClient, CosmosClient cosmosClient)
 {
-    private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfig _configuration = configuration.Value;
-
     [Function(AgentActivityName.SubmitReservationAgent)]
     public string Run([ActivityTrigger] SubmitReservationRequest req, FunctionContext executionContext)
     {

--- a/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
@@ -5,10 +5,10 @@ using Microsoft.Extensions.Options;
 
 namespace DurableMultiAgentTemplate.Agent.SubmitReservationAgent;
 
-public class SubmitReservationActivity(AzureOpenAIClient openAIClient, IOptions<AppConfiguration> configuration)
+public class SubmitReservationActivity(AzureOpenAIClient openAIClient, IOptions<AppConfig> configuration)
 {
     private readonly AzureOpenAIClient _openAIClient = openAIClient;
-    private readonly AppConfiguration _configuration = configuration.Value;
+    private readonly AppConfig _configuration = configuration.Value;
 
     [Function(AgentActivityName.SubmitReservationAgent)]
     public string Run([ActivityTrigger] SubmitReservationRequest req, FunctionContext executionContext)

--- a/DurableMultiAgentTemplate/DurableMultiAgentTemplate.csproj
+++ b/DurableMultiAgentTemplate/DurableMultiAgentTemplate.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
     <!-- Application Insights isn't enabled by default. See https://aka.ms/AAt8mw4. -->
     <!-- <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" /> -->
     <!-- <PackageReference Include="Microsoft.Azure.Functions.Worker.ApplicationInsights" Version="2.0.0" /> -->

--- a/DurableMultiAgentTemplate/Model/AppConfig.cs
+++ b/DurableMultiAgentTemplate/Model/AppConfig.cs
@@ -1,0 +1,20 @@
+﻿namespace DurableMultiAgentTemplate.Model;
+
+public class AppConfig
+{
+    public required OpenAIConfig OpenAI { get; init; }
+    public required CosmosDbConfig CosmosDb { get; init; }
+}
+
+public class OpenAIConfig
+{
+    public required string Endpoint { get; init; }
+    public string? ApiKey { get; init; }
+    public required string Deploy { get; init; }
+}
+
+public class CosmosDbConfig
+{
+    public required string Endpoint { get; init; }
+    public string? ApiKey { get; init; }
+}

--- a/DurableMultiAgentTemplate/Model/AppConfig.cs
+++ b/DurableMultiAgentTemplate/Model/AppConfig.cs
@@ -10,7 +10,8 @@ public class OpenAIConfig
 {
     public required string Endpoint { get; init; }
     public string? ApiKey { get; init; }
-    public required string Deploy { get; init; }
+    public required string ChatModelDeployName { get; init; }
+    public required string EmbeddingModelDeployName { get; init; }
 }
 
 public class CosmosDbConfig

--- a/DurableMultiAgentTemplate/Model/AppConfiguration.cs
+++ b/DurableMultiAgentTemplate/Model/AppConfiguration.cs
@@ -1,5 +1,0 @@
-public class AppConfiguration
-{
-    public string OpenAIEndpoint { get; set; } = string.Empty;
-    public string OpenAIDeploy { get; set; } = string.Empty;
-}

--- a/DurableMultiAgentTemplate/Program.cs
+++ b/DurableMultiAgentTemplate/Program.cs
@@ -1,13 +1,17 @@
 ﻿using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
+using Azure;
 using Azure.AI.OpenAI;
 using Azure.Core;
 using Azure.Identity;
+using DurableMultiAgentTemplate.Model;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Azure.Functions.Worker.Builder;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
 
 var builder = FunctionsApplication.CreateBuilder(args);
 
@@ -15,23 +19,44 @@ builder.ConfigureFunctionsWebApplication();
 
 var configuration = builder.Configuration;
 
-builder.Services.Configure<AppConfiguration>(configuration.GetSection("AppConfig"));
+builder.Services.Configure<AppConfig>(configuration.GetSection("AppConfig"));
 
 builder.Services
     .AddAzureClients(clientBuilder =>
         {
-            clientBuilder.AddClient<AzureOpenAIClient, AzureOpenAIClientOptions>(options =>
+            clientBuilder.AddClient<AzureOpenAIClient, AzureOpenAIClientOptions>(static (options, credential, provider) =>
             {
-                var endpoint = builder.Configuration["AppConfig:OpenAIEndpoint"];
-                if (string.IsNullOrEmpty(endpoint)) throw new InvalidOperationException("AppConfig:OpenAIEndpoint is required.");
+                var appConfig = provider.GetRequiredService<IOptions<AppConfig>>().Value;
+                if (string.IsNullOrEmpty(appConfig.OpenAI.Endpoint)) 
+                    throw new InvalidOperationException("AppConfig:OpenAI:Endpoint is required.");
 
-                TokenCredential credential = builder.Environment.IsDevelopment() ?
-                    new AzureCliCredential() :
-                    new DefaultAzureCredential();
+                return string.IsNullOrWhiteSpace(appConfig.OpenAI.ApiKey) ?
+                    new AzureOpenAIClient(new Uri(appConfig.OpenAI.Endpoint), credential, options) :
+                    new AzureOpenAIClient(new Uri(appConfig.OpenAI.Endpoint), new AzureKeyCredential(appConfig.OpenAI.ApiKey), options);
+            }).ConfigureOptions(builder.Configuration.GetSection("AppConfig:OpenAI"));
 
-                return new AzureOpenAIClient(new Uri(endpoint), credential, options);
-            });
+            clientBuilder.AddClient<CosmosClient, CosmosClientOptions>(static (options, credential, provider) =>
+            {
+                var appConfig = provider.GetRequiredService<IOptions<AppConfig>>().Value;
+                if (string.IsNullOrEmpty(appConfig.CosmosDb.Endpoint))
+                    throw new InvalidOperationException("AppConfig:CosmosDb:Endpoint is required.");
+
+                return string.IsNullOrWhiteSpace(appConfig.CosmosDb.ApiKey) ?
+                    new CosmosClient(appConfig.CosmosDb.Endpoint, credential, options) :
+                    new CosmosClient(appConfig.CosmosDb.Endpoint, new AzureKeyCredential(appConfig.CosmosDb.ApiKey), options);
+            }).ConfigureOptions(builder.Configuration.GetSection("AppConfig:CosmosDb"));
+
+            clientBuilder.UseCredential(builder.Environment.IsDevelopment() ?
+                new AzureCliCredential() :
+                new DefaultAzureCredential());
         });
+
+builder.Services.AddSingleton(sp =>
+{
+    var appConfiguration = sp.GetRequiredService<IOptions<AppConfig>>().Value;
+    var openAIClient = sp.GetRequiredService<AzureOpenAIClient>();
+    return openAIClient.GetChatClient(appConfiguration.OpenAI.Deploy);
+});
 
 builder.Services.Configure<JsonSerializerOptions>(jsonSerializerOptions =>
     {

--- a/DurableMultiAgentTemplate/Program.cs
+++ b/DurableMultiAgentTemplate/Program.cs
@@ -43,7 +43,7 @@ builder.Services
 
                 return string.IsNullOrWhiteSpace(appConfig.CosmosDb.ApiKey) ?
                     new CosmosClient(appConfig.CosmosDb.Endpoint, credential, options) :
-                    new CosmosClient(appConfig.CosmosDb.Endpoint, new AzureKeyCredential(appConfig.CosmosDb.ApiKey), options);
+                    new CosmosClient(appConfig.CosmosDb.Endpoint, appConfig.CosmosDb.ApiKey, options);
             }).ConfigureOptions(builder.Configuration.GetSection("AppConfig:CosmosDb"));
 
             clientBuilder.UseCredential(builder.Environment.IsDevelopment() ?

--- a/DurableMultiAgentTemplate/Program.cs
+++ b/DurableMultiAgentTemplate/Program.cs
@@ -54,8 +54,16 @@ builder.Services
 builder.Services.AddSingleton(sp =>
 {
     var appConfiguration = sp.GetRequiredService<IOptions<AppConfig>>().Value;
+    _ = appConfiguration.OpenAI.ChatModelDeployName ?? throw new InvalidOperationException("AppConfig:OpenAI:ChatModelDeployName is required.");
     var openAIClient = sp.GetRequiredService<AzureOpenAIClient>();
-    return openAIClient.GetChatClient(appConfiguration.OpenAI.Deploy);
+    return openAIClient.GetChatClient(appConfiguration.OpenAI.ChatModelDeployName);
+});
+builder.Services.AddSingleton(sp =>
+{ 
+    var appConfiguration = sp.GetRequiredService<IOptions<AppConfig>>().Value;
+    _ = appConfiguration.OpenAI.EmbeddingModelDeployName ?? throw new InvalidOperationException("AppConfig:OpenAI:EmbeddingModelDeployName is required.");
+    var openAIClient = sp.GetRequiredService<AzureOpenAIClient>();
+    return openAIClient.GetEmbeddingClient(appConfiguration.OpenAI.EmbeddingModelDeployName);
 });
 
 builder.Services.Configure<JsonSerializerOptions>(jsonSerializerOptions =>

--- a/DurableMultiAgentTemplate/local.settings.json
+++ b/DurableMultiAgentTemplate/local.settings.json
@@ -4,9 +4,10 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "AppConfig:OpenAI:Endpoint": "https://<your AOAI resource name>.openai.azure.com/",
-    "AppConfig:OpenAI:Deploy": "deploy",
+    "AppConfig:OpenAI:ChatModelDeployName": "chat-model-deploy-name",
+    "AppConfig:OpenAI:EmbeddingModelDeployName": "embedding-model-deploy-name",
     "AppConfig:OpenAI:ApiKey": "",
-    "AppConfig:CosmosDb:Endpoint": "your cosmosdb endopoint",
+    "AppConfig:CosmosDb:Endpoint": "your cosmos endpoint",
     "AppConfig:CosmosDb:ApiKey": ""
   }
 }

--- a/DurableMultiAgentTemplate/local.settings.json
+++ b/DurableMultiAgentTemplate/local.settings.json
@@ -1,9 +1,12 @@
 {
-    "IsEncrypted": false,
-    "Values": {
-        "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-        "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
-        "AppConfig:OpenAIEndpoint": "https://{your endpoint}.openai.azure.com/",
-        "AppConfig:OpenAIDeploy": "deploy"
-    }
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AppConfig:OpenAI:Endpoint": "https://<your AOAI resource name>.openai.azure.com/",
+    "AppConfig:OpenAI:Deploy": "deploy",
+    "AppConfig:OpenAI:ApiKey": "",
+    "AppConfig:CosmosDb:Endpoint": "your cosmosdb endopoint",
+    "AppConfig:CosmosDb:ApiKey": ""
+  }
 }

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ if(Random.Shared.Next(0, 10) < 3)
 0. Before running, create the following resources:
    - Azure OpenAI Service with a deployed chat completions model (embedding model deployment is optional)
    - Azure Cosmos DB (optional, if used)
+      - Instead of Azure Cosmos DB, you can also use the Azure Cosmos DB Emulator. For more details, please refer to the documentation below.<br/>
+      [Develop locally using the Azure Cosmos DB emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=windows%2Ccsharp&pivots=api-nosql)
 
 1. Update the `local.settings.json` of the `DurableMultiAgentTemplate` project with your resource information below:   
    - Azure OpenAI endpoint and deployment name  
    - Azure Cosmos DB endpoint (optional if not used)  
-      - Instead of Azure Cosmos DB, you can also use the Azure Cosmos DB Emulator. For more details, please refer to the documentation below.<br/>
-      [Develop locally using the Azure Cosmos DB emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=windows%2Ccsharp&pivots=api-nosql)
      
    You can choose between API key or Entra ID authentication for each service:  
    - If using an API key: Include the API key in the `local.settings.json` file.  

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ if(Random.Shared.Next(0, 10) < 3)
 1. Update the `local.settings.json` of the `DurableMultiAgentTemplate` project with your resource information below:   
    - Azure OpenAI endpoint and deployment name  
    - Azure Cosmos DB endpoint (optional if not used)  
+      - Instead of Azure Cosmos DB, you can also use the Azure Cosmos DB Emulator. For more details, please refer to the documentation below.<br/>
+      [Develop locally using the Azure Cosmos DB emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/how-to-develop-emulator?tabs=windows%2Ccsharp&pivots=api-nosql)
      
    You can choose between API key or Entra ID authentication for each service:  
    - If using an API key: Include the API key in the `local.settings.json` file.  

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ When implementing an actual Agent based on the sample Agent, please remove the f
 ```cs
 if(Random.Shared.Next(0, 10) < 3)
 {
-	logger.LogInformation("Failed to get climate information");
-	throw new InvalidOperationException("Failed to get climate information");
+    logger.LogInformation("Failed to get climate information");
+    throw new InvalidOperationException("Failed to get climate information");
 }
 ```
 
@@ -61,13 +61,13 @@ if(Random.Shared.Next(0, 10) < 3)
    - Azure OpenAI Service with a deployed chat completions model (embedding model deployment is optional)
    - Azure Cosmos DB (optional, if used)
 
-1. Update the `localsettings.json` of the `DurableMultiAgentTemplate` project with your resource information below:   
+1. Update the `local.settings.json` of the `DurableMultiAgentTemplate` project with your resource information below:   
    - Azure OpenAI endpoint and deployment name  
    - Azure Cosmos DB endpoint (optional if not used)  
      
    You can choose between API key or Entra ID authentication for each service:  
-   - If using an API key: Include the API key in the `localsettings.json` file.  
-   - If using Entra ID authentication: Authenticate using the `az login` command with Azure CLI. Leave the API key blank in the `localsettings.json` file. Note that **the authenticated user must have RBAC permissions for each service.**
+   - If using an API key: Include the API key in the `local.settings.json` file.  
+   - If using Entra ID authentication: Authenticate using the `az login` command with Azure CLI. Leave the API key blank in the `local.settings.json` file. Note that **the authenticated user must have RBAC permissions for each service.**
 
 2. Run the project.
 
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/10425f9a-cd55-4f02-8cd1-6a1935df4db0
 2. Select `Multi agent test` as the startup project.
    - This will run both the Durable Functions and .NET client projects simultaneously.
 3. Press `F5` to run the projects.
-   - If you encounter an error, please check the `localsettings.json` file in the `DurableMultiAgentTemplate` project.
+   - If you encounter an error, please check the `local.settings.json` file in the `DurableMultiAgentTemplate` project.
 
 ### Visual Studio Code
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -61,13 +61,13 @@ if(Random.Shared.Next(0, 10) < 3)
 	- Azure OpenAI Serviceとチャット補完モデルのデプロイ（埋め込みモデルのデプロイは任意）
 	- Azure Cosmos DB（使用しない場合は省略可能）
 
-1. `DurableMultiAgentTemplate` プロジェクトの `localsettings.json` を更新し、ご自身の以下のリソースの情報を設定します。
+1. `DurableMultiAgentTemplate` プロジェクトの `local.settings.json` を更新し、ご自身の以下のリソースの情報を設定します。
 	- Azure OpenAIのエンドポイントとデプロイ名
 	- Azure Cosmos DBのエンドポイント（使用しない場合は省略可能）
 
 	各サービスへの認証はAPIキーまたはEntra ID認証を選択できます。
-	- APIキーを使用する場合：`localsettings.json` ファイルにAPIキーを記述してください。
-	- Entra ID認証を使用する場合：Azure CLIを使用して`az login`コマンドで認証してください。`localsettings.json` ファイルAPIキーは空白にしてください。この際に、**認証したユーザーに各サービスのRBACが付与されている必要があることに注意してください。**
+	- APIキーを使用する場合：`local.settings.json` ファイルにAPIキーを記述してください。
+	- Entra ID認証を使用する場合：Azure CLIを使用して`az login`コマンドで認証してください。`local.settings.json` ファイルAPIキーは空白にしてください。この際に、**認証したユーザーに各サービスのRBACが付与されている必要があることに注意してください。**
 
 2. プロジェクトを実行します。
 
@@ -86,7 +86,7 @@ https://github.com/user-attachments/assets/10425f9a-cd55-4f02-8cd1-6a1935df4db0
 2. スタートアッププロジェクトとして `Multi agent test` を選択します。
    - これにより、Durable Functions プロジェクトと .NET クライアントプロジェクトの両方が同時に実行されます。
 3. `F5` を押してプロジェクトを実行します。
-   - エラーが発生した場合は、`DurableMultiAgentTemplate` プロジェクトの `localsettings.json` ファイルを確認してください。
+   - エラーが発生した場合は、`DurableMultiAgentTemplate` プロジェクトの `local.settings.json` ファイルを確認してください。
 
 #### Visual Studio Code での実行
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -60,6 +60,8 @@ if(Random.Shared.Next(0, 10) < 3)
 0. 事前に以下のリソースを作成してください。
 	- Azure OpenAI Serviceとチャット補完モデルのデプロイ（埋め込みモデルのデプロイは任意）
 	- Azure Cosmos DB（使用しない場合は省略可能）
+       - Azure Cosmos DBの代わりに、Azure Cosmos DB Emulator（エミュレーター）を使用することもできます。詳細については、以下のドキュメントをご参照ください。  
+       [Azure Cosmos DB エミュレーターを使用したローカルでの開発](https://learn.microsoft.com/ja-jp/azure/cosmos-db/how-to-develop-emulator?tabs=windows%2Ccsharp&pivots=api-nosql)
 
 1. `DurableMultiAgentTemplate` プロジェクトの `local.settings.json` を更新し、ご自身の以下のリソースの情報を設定します。
 	- Azure OpenAIのエンドポイントとデプロイ名


### PR DESCRIPTION
Fix #23 

### 主な変更点
- [x] CosmosClient の追加
- [x] local.settings.json に Cosmos への設定を追加
- [x] OpenAI の ApiKey 対応 (ApiKey が設定されていない場合は Managed ID 認証)
- [x] CosmosDB の ApiKey 対応 (ApiKey が設定されていない場合は Managed ID 認証)
- [x] Activity で AOAIClient ではなく ChatClient を使うように変更
- [x] EmbeddingClient 対応
- [x] local.settings.json に ChatModel と EmbeddingModel のデプロイ名を設定可能に変更
- [x] Chat のタイムアウトがデフォルト20秒だったがたまにタイムアウトするので60秒に変更