### PR TITLE
Agent管理単位の改善

### DIFF
--- a/DurableMultiAgentTemplate.Test/Orchestrator/SynthesizerActivityTest.cs
+++ b/DurableMultiAgentTemplate.Test/Orchestrator/SynthesizerActivityTest.cs
@@ -2,6 +2,7 @@
 using System.ClientModel.Primitives;
 using DurableMultiAgentTemplate.Agent;
 using DurableMultiAgentTemplate.Agent.Orchestrator;
+using DurableMultiAgentTemplate.Agent.Synthesizer;
 using DurableMultiAgentTemplate.Model;
 using DurableMultiAgentTemplate.Shared.Model;
 using Microsoft.Extensions.Logging;

--- a/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderActivity.cs
@@ -1,13 +1,12 @@
 ﻿using System.Text.Json;
 using DurableMultiAgentTemplate.Extension;
-using DurableMultiAgentTemplate.Model;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 using DurableMultiAgentTemplate.Shared.Model;
 
 
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.AgentDecider;
 
 public class AgentDeciderActivity(ChatClient chatClient, ILogger<AgentDeciderActivity> logger)
 {

--- a/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderPrompt.cs
+++ b/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderPrompt.cs
@@ -1,4 +1,4 @@
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.AgentDecider;
 
 internal static class AgentDeciderPrompt
 {

--- a/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderResult.cs
+++ b/DurableMultiAgentTemplate/Agent/AgentDecider/AgentDeciderResult.cs
@@ -1,6 +1,6 @@
 ﻿using DurableMultiAgentTemplate.Shared.Model;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.AgentDecider;
 
 public class AgentDeciderResult
 {

--- a/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateActivity.cs
@@ -1,5 +1,4 @@
-﻿using DurableMultiAgentTemplate.Model;
-using Microsoft.Azure.Functions.Worker;
+﻿using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 

--- a/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/GetClimateAgent/GetClimateRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.GetClimateAgent;
 
 public class GetClimateRequest
 {

--- a/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestActivity.cs
@@ -1,5 +1,4 @@
-﻿using DurableMultiAgentTemplate.Model;
-using Microsoft.Azure.Functions.Worker;
+﻿using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 

--- a/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/GetDestinationSuggestAgent/GetDestinationSuggestRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.GetDestinationSuggestAgent;
 
 public class GetDestinationSuggestRequest
 {

--- a/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelActivity.cs
@@ -1,5 +1,4 @@
-﻿using DurableMultiAgentTemplate.Model;
-using Microsoft.Azure.Functions.Worker;
+﻿using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 

--- a/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/GetHotelAgent/GetHotelRequest.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.GetHotelAgent;
 
-public class GetSightseeingSpotRequest
+public class GetHotelRequest
 {
     [Description("場所の名前。例: ボストン, 東京、フランス")]
     public required string Location { get; set; } = string.Empty;

--- a/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotActivity.cs
@@ -1,5 +1,4 @@
-﻿using DurableMultiAgentTemplate.Model;
-using Microsoft.Azure.Functions.Worker;
+﻿using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 

--- a/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/GetSightseeingSpotAgent/GetSightseeingSpotRequest.cs
@@ -1,8 +1,8 @@
 ﻿using System.ComponentModel;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.GetSightseeingSpotAgent;
 
-public class GetHotelRequest
+public class GetSightseeingSpotRequest
 {
     [Description("場所の名前。例: ボストン, 東京、フランス")]
     public required string Location { get; set; } = string.Empty;

--- a/DurableMultiAgentTemplate/Agent/Orchestrator/AgentOrchestrator.cs
+++ b/DurableMultiAgentTemplate/Agent/Orchestrator/AgentOrchestrator.cs
@@ -3,6 +3,8 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.DurableTask;
 using Microsoft.Extensions.Logging;
 using DurableMultiAgentTemplate.Shared.Model;
+using DurableMultiAgentTemplate.Agent.AgentDecider;
+using DurableMultiAgentTemplate.Agent.Synthesizer;
 
 namespace DurableMultiAgentTemplate.Agent.Orchestrator;
 

--- a/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationActivity.cs
@@ -1,5 +1,4 @@
-﻿using DurableMultiAgentTemplate.Model;
-using Microsoft.Azure.Functions.Worker;
+﻿using Microsoft.Azure.Functions.Worker;
 using OpenAI.Chat;
 
 namespace DurableMultiAgentTemplate.Agent.SubmitReservationAgent;

--- a/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/SubmitReservationAgent/SubmitReservationRequest.cs
@@ -1,6 +1,6 @@
 ﻿using System.ComponentModel;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.SubmitReservationAgent;
 
 public class SubmitReservationRequest
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/AgentResponseWithAdditionalInfoFormat.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/AgentResponseWithAdditionalInfoFormat.cs
@@ -1,6 +1,6 @@
 using DurableMultiAgentTemplate.Shared.Model;
 
-namespace DurableMultiAgentTemplate;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 public class AgentResponseWithAdditionalInfoFormat
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerActivity.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using OpenAI.Chat;
 using DurableMultiAgentTemplate.Shared.Model;
 
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 public class SynthesizerActivity(ChatClient chatClient, ILogger<SynthesizerActivity> logger)
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerPrompt.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerPrompt.cs
@@ -1,4 +1,4 @@
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 internal static class SynthesizerPrompt
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerRequest.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerRequest.cs
@@ -1,6 +1,6 @@
 using DurableMultiAgentTemplate.Shared.Model;
 
-namespace DurableMultiAgentTemplate.Model;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 public class SynthesizerRequest
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerWithAdditionalInfoActivity.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerWithAdditionalInfoActivity.cs
@@ -8,7 +8,7 @@ using OpenAI.Chat;
 using DurableMultiAgentTemplate.Shared.Model;
 
 
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 public class SynthesizerWithAdditionalInfoActivity(ChatClient chatClient, ILogger<SynthesizerWithAdditionalInfoActivity> logger)
 {

--- a/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerWithAdditionalInfoPrompt.cs
+++ b/DurableMultiAgentTemplate/Agent/Synthesizer/SynthesizerWithAdditionalInfoPrompt.cs
@@ -1,4 +1,4 @@
-namespace DurableMultiAgentTemplate.Agent.Orchestrator;
+namespace DurableMultiAgentTemplate.Agent.Synthesizer;
 
 internal static class SynthesizerWithAdditionalInfoPrompt
 {

--- a/DurableMultiAgentTemplate/Model/SourceGenerationContext.cs
+++ b/DurableMultiAgentTemplate/Model/SourceGenerationContext.cs
@@ -1,4 +1,10 @@
 ﻿using System.Text.Json.Serialization;
+using DurableMultiAgentTemplate.Agent.GetClimateAgent;
+using DurableMultiAgentTemplate.Agent.GetDestinationSuggestAgent;
+using DurableMultiAgentTemplate.Agent.GetHotelAgent;
+using DurableMultiAgentTemplate.Agent.GetSightseeingSpotAgent;
+using DurableMultiAgentTemplate.Agent.SubmitReservationAgent;
+using DurableMultiAgentTemplate.Agent.Synthesizer;
 using DurableMultiAgentTemplate.Shared.Model;
 
 namespace DurableMultiAgentTemplate.Model;


### PR DESCRIPTION
Fix #35 

- 各エージェント、オーケストレーターのインターフェースモデルをModelsディレクトリから各エージェントのディレクトリに移動